### PR TITLE
Add chess as a dependency and write a simple test that initializes a chess board and makes an opening move

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Andrei Savu <savu.andrei@gmail.com>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 click = "^8.0.1"
+chess = "^1.10.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/tests/test_chess.py
+++ b/tests/test_chess.py
@@ -2,5 +2,5 @@ import chess
 
 def test_chess_opening_move():
     board = chess.Board()
-    board.push_san("e4")
-    assert board.san(board.peek()) == "e4"
+    board.push(chess.Move.from_uci("e2e4"))
+    assert board.peek() == chess.Move.from_uci("e2e4")

--- a/tests/test_chess.py
+++ b/tests/test_chess.py
@@ -1,0 +1,6 @@
+import chess
+
+def test_chess_opening_move():
+    board = chess.Board()
+    board.push_san("e4")
+    assert board.san(board.peek()) == "e4"


### PR DESCRIPTION
Add chess as a dependency and create a test for initializing a chess board and making an opening move.

* **Dependency Addition**
  - Add `chess` as a dependency in `pyproject.toml`.

* **Test Creation**
  - Create a new test file `tests/test_chess.py`.
  - Import `chess` in the new test file.
  - Define a test function `test_chess_opening_move`.
  - Initialize a chess board using `chess.Board()`.
  - Make an opening move using `board.push_san("e4")`.
  - Assert that the move was made correctly using `assert board.san(board.peek()) == "e4"`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/chess-codegen?shareId=a7a9310f-7227-4ab0-9c0c-8278b8e0ec69).